### PR TITLE
Fix for installation on i386 architecture

### DIFF
--- a/lib/droonga/serf_downloader.rb
+++ b/lib/droonga/serf_downloader.rb
@@ -77,7 +77,7 @@ module Droonga
       when /x86_64|x64/
         @architecture = "amd64"
       when /i\d86/
-        @architecture = "i386"
+        @architecture = "386"
       else
         raise "Unsupported architecture: #{RUBY_PLATFORM}"
       end


### PR DESCRIPTION
Fixed: fails installation if the architecture is i386
